### PR TITLE
87 feedback from malte only show course filters after user has started typing in the searchbar

### DIFF
--- a/src/components/input/Input.module.css
+++ b/src/components/input/Input.module.css
@@ -16,17 +16,14 @@
 }
 
 .inputWrapper {
-    transition:
-        border-color 0.5s ease,
-        padding 0.5s ease;
+    transition: border-color 0.5s ease;
     border: 3px solid transparent;
-    padding: 0;
+    padding: 2px;
 }
 
 .highlight {
     border-radius: 6px;
     border-color: var(--input-focused);
-    padding: 2px;
 }
 
 .label {

--- a/src/components/input/Input.module.css
+++ b/src/components/input/Input.module.css
@@ -18,7 +18,7 @@
 .inputWrapper {
     transition: border-color 0.5s ease;
     border: 3px solid transparent;
-    padding: 2px;
+    padding: 1px;
 }
 
 .highlight {

--- a/src/components/questionFinder/QuestionFinder.tsx
+++ b/src/components/questionFinder/QuestionFinder.tsx
@@ -12,11 +12,6 @@ const tabContainerStyle: CSSProperties = {
     marginTop: "clamp(0.2rem, 5vw, 2rem)",
 };
 
-const tabsOuterContainerStyle: CSSProperties = {
-    width: "100%",
-    flexDirection: "column",
-};
-
 const tabsBtnStyle: CSSProperties = {
     fontSize: "clamp(12px, 2vw, 1.5rem)",
     flex: 1,
@@ -32,9 +27,16 @@ export function QuestionFinder() {
         onResolvedFilterClick,
         activeFilters,
         onInterActionFilterClick,
+        shouldShowFilters,
     } = useSearchQuestions();
     const { t } = useTranslation();
     const { isUser } = useRoles();
+
+    const tabsOuterContainerStyle: CSSProperties = {
+        width: "100%",
+        flexDirection: "column",
+        transition: "transform 0.5s ease",
+    };
 
     const questionListContent = useMemo(
         () => (
@@ -96,6 +98,7 @@ export function QuestionFinder() {
     return (
         <div className={styles.container}>
             <SearchWithFilters
+                shouldShowFilters={shouldShowFilters}
                 placeholder={t("searchQuestionsPlaceholder")}
                 subjectFilter={subjectFilterProps}
                 topicFilter={topicFilterProps}

--- a/src/components/search/searchWithFilters/SearchWithFilters.module.css
+++ b/src/components/search/searchWithFilters/SearchWithFilters.module.css
@@ -2,18 +2,21 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: 15px;
 }
 
 .filterWrapper {
-    visibility: hidden;
     pointer-events: none;
-    /* Adjust min-height with respect to height of a FilterButton to prevent components jumping the first
-    time topicFilters are rendered */
-    min-height: 46px;
+    max-height: 0;
+    overflow: hidden;
+    transform-origin: top; /* Ensures scaling happens from the top */
+    transition: max-height 0.5s ease;
+}
+
+.subjectFilterWrapper {
+    padding-block: 1rem;
 }
 
 .show {
+    max-height: 100px;
     pointer-events: all;
-    visibility: visible;
 }

--- a/src/components/search/searchWithFilters/SearchWithFilters.tsx
+++ b/src/components/search/searchWithFilters/SearchWithFilters.tsx
@@ -30,12 +30,10 @@ export function SearchWithFilters(props: ISearchWithFiltersProps) {
             </div>
 
             <div
+                data-testid="topicFilterWrapper"
                 className={`${styles.filterWrapper} ${props.shouldShowFilters.topic ? styles.show : ""}`}
             >
-                <div
-                    data-testid="topicFilterWrapper"
-                    className={styles.topicFilterWrapper}
-                >
+                <div className={styles.topicFilterWrapper}>
                     <SearchFilter
                         title={`${t("topicFilter")}:`}
                         onFilterClick={props.topicFilter.onFilterClick}

--- a/src/components/search/searchWithFilters/SearchWithFilters.tsx
+++ b/src/components/search/searchWithFilters/SearchWithFilters.tsx
@@ -6,8 +6,9 @@ import styles from "./SearchWithFilters.module.css";
 
 export function SearchWithFilters(props: ISearchWithFiltersProps) {
     const { t } = useTranslation();
-    const showTopics =
-        props.subjectFilter.activeFilter && !props.isLoadingQuestions;
+    // const showTopicFilters =
+    //     props.subjectFilter.activeFilter && !props.isLoadingQuestions;
+    // const showSubjectFilters = props.subjectFilter.displayedFilters.length > 0;
     return (
         <div className={styles.container}>
             <SearchBar
@@ -15,24 +16,33 @@ export function SearchWithFilters(props: ISearchWithFiltersProps) {
                 placeholder={props.placeholder}
                 onInputChange={props.onInputChange}
             />
-
-            <SearchFilter
-                title={`${t("categoryFilter")}:`}
-                onFilterClick={props.subjectFilter.onFilterClick}
-                displayedFilters={props.subjectFilter.displayedFilters}
-                activeFilter={props.subjectFilter.activeFilter}
-            />
+            <div
+                className={`${styles.filterWrapper} ${props.shouldShowFilters.subject ? styles.show : ""}`}
+            >
+                <div className={styles.subjectFilterWrapper}>
+                    <SearchFilter
+                        title={`${t("categoryFilter")}:`}
+                        onFilterClick={props.subjectFilter.onFilterClick}
+                        displayedFilters={props.subjectFilter.displayedFilters}
+                        activeFilter={props.subjectFilter.activeFilter}
+                    />
+                </div>
+            </div>
 
             <div
-                data-testid="topicFilterWrapper"
-                className={`${styles.filterWrapper} ${showTopics ? styles.show : ""}`}
+                className={`${styles.filterWrapper} ${props.shouldShowFilters.topic ? styles.show : ""}`}
             >
-                <SearchFilter
-                    title={`${t("topicFilter")}:`}
-                    onFilterClick={props.topicFilter.onFilterClick}
-                    displayedFilters={props.topicFilter.displayedFilters}
-                    activeFilter={props.topicFilter.activeFilter}
-                />
+                <div
+                    data-testid="topicFilterWrapper"
+                    className={styles.topicFilterWrapper}
+                >
+                    <SearchFilter
+                        title={`${t("topicFilter")}:`}
+                        onFilterClick={props.topicFilter.onFilterClick}
+                        displayedFilters={props.topicFilter.displayedFilters}
+                        activeFilter={props.topicFilter.activeFilter}
+                    />
+                </div>
             </div>
         </div>
     );

--- a/src/components/search/searchWithFilters/searchFilter/SearchFilter.module.css
+++ b/src/components/search/searchWithFilters/searchFilter/SearchFilter.module.css
@@ -12,7 +12,7 @@
     -ms-overflow-style: none; /* IE and Edge */
 }
 
-.container::-webkit-scrollbar {
+.scrollContainer::-webkit-scrollbar {
     display: none; /*Chrome, Safari */
 }
 
@@ -21,9 +21,6 @@
     display: flex;
     gap: 15px;
     width: max-content;
-    /* Adjust min-height with respect to the height of filterWrapper in SearchWithFilter.module.css to prevent
-    components jumping around*/
-    min-height: 46px;
 }
 
 .title {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -36,7 +36,7 @@
         "emailTaken": "Email is already in use. Please try another one.",
         "verifyEmail": "A verification email has been sent to your email address. Please check your inbox and follow the instructions to verify your account.",
         "searchQuestionsPlaceholder": "Search questions by title, course code, course name, tag, or topic",
-        "searchQuestions": "Search question",
+        "searchQuestions": "Search questions",
         "askAQuestion": "Ask a question",
         "teacher": "Teacher",
         "categoryFilter": "Course filter",

--- a/src/mocks/network/handlers.ts
+++ b/src/mocks/network/handlers.ts
@@ -7,11 +7,18 @@ export const handlers = [
     http.get(`${BASE_URL}/questions/public`, ({ request }) => {
         const url = new URL(request.url);
         const subjectId = url.searchParams.get("subjectId");
+        const searchString = url.searchParams.get("searchString");
 
         if (subjectId === "subject-1") {
             mockAPI(subjectId);
             return HttpResponse.json([questions[0]]);
         }
+
+        if (searchString === "subj") {
+            mockAPI(searchString);
+            return HttpResponse.json(questions);
+        }
+
         mockAPI();
 
         return HttpResponse.json(questions);
@@ -44,7 +51,7 @@ const questions: IQuestion[] = Array.from({ length: 10 }, (_, index) => ({
     subjectId: `subject-${index + 1}`,
     subjectName: `Subject ${index + 1}`,
     subjectCode: `SUBJ${index + 1}`,
-    username: `user${index + 1}`,
+    userName: `user${index + 1}`,
     title: `Question Title ${index + 1}`,
     created: randomDate(),
     isResolved: index % 2 === 0, // Alternate between resolved and unresolved

--- a/src/pages/home/HomeSharedStyle.module.css
+++ b/src/pages/home/HomeSharedStyle.module.css
@@ -1,7 +1,7 @@
 .container {
     display: flex;
     flex-direction: column;
-    padding-top: clamp(1rem, 5vw, 4rem);
+    padding-top: clamp(1rem, 5vw, 1.3rem);
     padding-inline: clamp(15px, 4vw, 10rem);
     align-items: center;
     flex: 1;

--- a/src/pages/home/homeExtended/HomeExtended.tsx
+++ b/src/pages/home/homeExtended/HomeExtended.tsx
@@ -6,16 +6,17 @@ import { ITab } from "../../../utils";
 import { CSSProperties, useMemo } from "react";
 
 const tabBtnsContainerStyle: CSSProperties = {
-    width: "clamp(290px, 90vw, 700px)",
+    maxWidth: "100%",
 };
 
 const btnStyle: CSSProperties = {
-    fontSize: "clamp(14px, 2vw, 1.2rem)",
-    flex: 1,
+    fontSize: "13px",
+    width: "max-content",
+    paddingBlock: "5px",
 };
 
 const questionFinderContainerStyle: CSSProperties = {
-    marginTop: "1.5rem",
+    marginTop: "1rem",
     width: "100%",
 };
 const tabsContainerStyle: CSSProperties = { width: "100%", maxWidth: "1600px" };

--- a/src/tests/integrationTests/QuestionFinder.test.tsx
+++ b/src/tests/integrationTests/QuestionFinder.test.tsx
@@ -76,6 +76,7 @@ describe("QuestionFinder", () => {
                 new MouseEvent("click", { bubbles: true, cancelable: true }),
             ),
         );
+
         //Check that the correct styling have been applied
         expect(firstSubjectFilter).toHaveClass("active");
 

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -5,6 +5,7 @@ import { server } from "../mocks/network/node";
 import { mockAPI } from "./testUtils";
 
 beforeAll(() => server.listen());
+
 afterEach(() => {
     server.resetHandlers();
     mockAPI.mockClear();

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -100,6 +100,7 @@ export interface ISearchWithFiltersProps extends ISearchBarProps {
     subjectFilter: ISearchFilter;
     topicFilter: ISearchFilter;
     isLoadingQuestions: boolean;
+    shouldShowFilters: IShouldShowFilters;
 }
 
 export interface IQuestionCardProps {
@@ -108,4 +109,9 @@ export interface IQuestionCardProps {
 
 export interface IQuestionCardListProps {
     data: IQuestionCardProps[];
+}
+
+export interface IShouldShowFilters {
+    subject: boolean;
+    topic: boolean;
 }


### PR DESCRIPTION
Typo in the third commit. Should be [make top tabs in homeExtended take up LESS space](https://github.com/stridsmaskinerna/QA-Platform-Frontend/pull/35/commits/f5908f5de88968eb83f902f7985e4e058cb8df24)